### PR TITLE
Use browserify instead of esmangle

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "index.js"
   ],
   "dependencies": {
-    "hast-util-raw": "^2.0.0"
+    "hast-util-raw": "^4.0.0"
   },
   "devDependencies": {
     "browserify": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build-md": "remark . -qfo",
     "build-bundle": "browserify index.js --bare -s rehypeRaw > rehype-raw.js",
-    "build-mangle": "esmangle rehype-raw.js > rehype-raw.min.js",
+    "build-mangle": "browserify index.js --bare -s rehypeRaw -p tinyify > rehype-raw.min.js",
     "build": "npm run build-md && npm run build-bundle && npm run build-mangle",
     "lint": "xo",
     "test-api": "node test.js",

--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
     "hast-util-raw": "^2.0.0"
   },
   "devDependencies": {
-    "browserify": "^14.1.0",
-    "esmangle": "^1.0.0",
-    "nyc": "^11.0.0",
-    "rehype-stringify": "^3.0.0",
-    "remark-cli": "^4.0.0",
-    "remark-parse": "^4.0.0",
-    "remark-preset-wooorm": "^3.0.0",
-    "remark-rehype": "^2.0.0",
+    "browserify": "^16.0.0",
+    "nyc": "^12.0.0",
+    "rehype-stringify": "^4.0.0",
+    "remark-cli": "^5.0.0",
+    "remark-parse": "^5.0.0",
+    "remark-preset-wooorm": "^4.0.0",
+    "remark-rehype": "^3.0.0",
     "tape": "^4.0.0",
-    "unified": "^6.0.0",
-    "xo": "^0.18.0"
+    "tinyify": "^2.4.3",
+    "unified": "^7.0.0",
+    "xo": "^0.21.0"
   },
   "scripts": {
     "build-md": "remark . -qfo",

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ var unified = require('unified');
 var parse = require('remark-parse');
 var remark2rehype = require('remark-rehype');
 var stringify = require('rehype-stringify');
-var raw = require('./');
+var raw = require('.');
 
 test('integration', function (t) {
   unified()


### PR DESCRIPTION
Hi o/
Update of dependencies and use of browserify instead of esmangle.

Basicaly the same as [hast-util-raw](https://github.com/syntax-tree/hast-util-raw/commits/master)

:two_hearts: 