### PR TITLE
Update hast-util-raw range to better development experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "@types/hast": "^2.0.0",
-    "hast-util-raw": "^7.2.0",
+    "hast-util-raw": "^9.0.0",
     "unified": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/rehypejs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/rehypejs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/rehypejs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Arehypejs&type=Issues -->
* [ ] If applicable, I’ve added docs and tests

### Description of changes

<!--do not edit: pr-->

in newly version there is much better error 
<img width="982" alt="image" src="https://github.com/rehypejs/rehype-raw/assets/7361780/feafb468-4427-447c-b073-3cc3f35821d5">

rather than in v7 `Error: Cannot compile 'mdxjsEsm' node`